### PR TITLE
Ensure database migrations run on startup

### DIFF
--- a/BlazoriumWASMS/Program.cs
+++ b/BlazoriumWASMS/Program.cs
@@ -7,6 +7,7 @@ using BlazoriumWASMS.Repository.IRepository;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace BlazoriumWASMS
 {
@@ -52,6 +53,13 @@ namespace BlazoriumWASMS
             builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>();
 
             var app = builder.Build();
+
+            // Ensure database is created and migrations are applied at startup
+            using (var scope = app.Services.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                db.Database.Migrate();
+            }
 
             // Configure the HTTP request pipeline.
             if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- Ensure ApplicationDbContext applies migrations at startup to create tables like Product
- Add required dependency injection namespace for GetRequiredService

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a14ba81c83299c79644ce9ffe4d5